### PR TITLE
サムネイル生成をやめる

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.14
 
 require (
 	cloud.google.com/go v0.54.0
+	github.com/dustin/go-humanize v1.0.0
 	github.com/gin-gonic/contrib v0.0.0-20191209060500-d6e26eeaa607
 	github.com/gin-gonic/gin v1.5.0
 	github.com/mattn/go-colorable v0.1.6

--- a/go.sum
+++ b/go.sum
@@ -32,6 +32,8 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
+github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/gin-contrib/sse v0.1.0 h1:Y/yl/+YNO8GZSjAhjMsSuLt29uWRFHdHYUb5lYOV9qE=

--- a/main.go
+++ b/main.go
@@ -45,18 +45,13 @@ func uploadHandlerFunc(client *vision.ImageAnnotatorClient) gin.HandlerFunc {
 		if err != nil {
 			panic(err)
 		}
-		thumb, err := imageupload.ThumbnailPNG(img, 300, 300)
-		if err != nil {
-			panic(err)
-		}
 
-		h := sha1.Sum(thumb.Data)
-
+		h := sha1.Sum(img.Data)
 		filepath := fmt.Sprintf(
 			"%s_%x.png",
 			time.Now().Format("20060102150405"), h[:4],
 		)
-		err = thumb.Save(filepath)
+		err = img.Save(filepath)
 		if err != nil {
 			panic(err)
 		}

--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/dustin/go-humanize"
 	"github.com/gin-gonic/contrib/static"
 	"github.com/gin-gonic/gin"
 	"github.com/mattn/go-colorable"
@@ -41,6 +42,12 @@ func main() {
 
 func uploadHandlerFunc(client *vision.ImageAnnotatorClient) gin.HandlerFunc {
 	return func(c *gin.Context) {
+		size, err := humanize.ParseBytes("10MB")
+		if err != nil {
+			log.Fatalf("%v", err)
+		}
+
+		imageupload.LimitFileSize(int64(size), c.Writer, c.Request)
 		img, err := imageupload.Process(c.Request, "file")
 		if err != nil {
 			panic(err)


### PR DESCRIPTION
サムネイルにする意味はあまりない

同時にファイルサイズの制限を導入
とりあえず10MB
